### PR TITLE
Replace ELK+Dagre layout with custom engine + dagre hybrid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "codevyr",
       "version": "0.1.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@monaco-editor/react": "^4.7.0",
         "@radix-ui/react-context-menu": "^2.2.7",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -15,8 +16,6 @@
         "@types/react": "18.3.3",
         "@types/react-dom": "18.3.0",
         "autoprefixer": "10.4.19",
-        "dagre": "^0.8.5",
-        "elkjs": "^0.10.0",
         "flexlayout-react": "0.8",
         "lz-string": "^1.5.0",
         "monaco-editor": "^0.53.0",
@@ -32,7 +31,6 @@
       },
       "devDependencies": {
         "@playwright/test": "1.58.2",
-        "@types/dagre": "^0.7.54",
         "eslint": "^9.0.1",
         "eslint-config-next": "^16.0.0",
         "miragejs": "^0.1.48",
@@ -291,6 +289,21 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -2632,13 +2645,6 @@
         "@types/d3-selection": "*"
       }
     },
-    "node_modules/@types/dagre": {
-      "version": "0.7.54",
-      "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.54.tgz",
-      "integrity": "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4479,16 +4485,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/dagre": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
-      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "graphlib": "^2.1.8",
-        "lodash": "^4.17.15"
-      }
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -4672,12 +4668,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
       "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
       "license": "ISC"
-    },
-    "node_modules/elkjs": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.10.2.tgz",
-      "integrity": "sha512-Yx3ORtbAFrXelYkAy2g0eYyVY8QG0XEmGdQXmy0eithKKjbWRfl3Xe884lfkszfBF6UKyIy4LwfcZ3AZc8oxFw==",
-      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5761,15 +5751,6 @@
       "dev": true,
       "license": "ISC",
       "peer": true
-    },
-    "node_modules/graphlib": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
-      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -6889,6 +6870,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-context-menu": "^2.2.7",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -16,8 +17,6 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.19",
-    "dagre": "^0.8.5",
-    "elkjs": "^0.10.0",
     "flexlayout-react": "0.8",
     "lz-string": "^1.5.0",
     "monaco-editor": "^0.53.0",
@@ -33,7 +32,6 @@
   },
   "devDependencies": {
     "@playwright/test": "1.58.2",
-    "@types/dagre": "^0.7.54",
     "eslint": "^9.0.1",
     "eslint-config-next": "^16.0.0",
     "miragejs": "^0.1.48",

--- a/src/app/graph_viewer.tsx
+++ b/src/app/graph_viewer.tsx
@@ -517,7 +517,7 @@ export const GraphViewer = forwardRef<GraphViewerHandle, GraphProps>(function Gr
     positionsRef, hierarchyRef, nodesRef,
     reactFlowInstanceRef,
     focusNode,
-    handleDagreLayout,
+    handleRelayout,
   } = useGraphLayout({ graph, selectFile, fileContents, ensureFileContent, revealDirectory, revealQueryRange, autoMerge });
 
   const [renderAllForCapture, setRenderAllForCapture] = useState(false);
@@ -656,10 +656,10 @@ export const GraphViewer = forwardRef<GraphViewerHandle, GraphProps>(function Gr
     centerGraph: handleCenterGraph,
     fitToView: handleFitToView,
     resetZoom: handleResetZoom,
-    redrawLayout: handleDagreLayout,
+    redrawLayout: handleRelayout,
     openSearch,
     takeScreenshot: handleScreenshot,
-  }), [handleCenterGraph, handleFitToView, handleResetZoom, handleDagreLayout, openSearch, handleScreenshot]);
+  }), [handleCenterGraph, handleFitToView, handleResetZoom, handleRelayout, openSearch, handleScreenshot]);
 
   // Group node bodies have pointer-events: none so edges underneath stay clickable.
   // When a pane click/contextmenu falls inside a group, forward it to the group's

--- a/src/app/lib/graph_layout.ts
+++ b/src/app/lib/graph_layout.ts
@@ -1,61 +1,63 @@
-import ELK from 'elkjs/lib/elk.bundled.js';
-import dagre from 'dagre';
 import type { Edge as FlowEdge, Node as FlowNode } from 'reactflow';
 import type { HierarchyInfo } from '../graph';
-
-const elk = new ELK();
-
-const DEFAULT_NODE_WIDTH = 180;
-const DEFAULT_NODE_HEIGHT = 40;
-const MAX_NODE_WIDTH = 320;
-const CHAR_WIDTH = 7;
+import { layoutGraph as layoutEngine } from './layout';
 
 export const GROUP_PAD_TOP = 40;
 export const GROUP_PAD_LEFT = 10;
 export const GROUP_PAD_BOTTOM = 10;
 export const GROUP_PAD_RIGHT = 10;
 
-function estimateNodeSize(label: string) {
-  const width = Math.min(
-    MAX_NODE_WIDTH,
-    Math.max(DEFAULT_NODE_WIDTH, label.length * CHAR_WIDTH + 32),
-  );
-  return {
-    width,
-    height: DEFAULT_NODE_HEIGHT,
-  };
+// ── DOM-based measurement (persistent hidden elements) ──────────
+
+// Persistent hidden span for measuring exact node label widths.
+// Uses the same CSS class as real graph nodes so the result is pixel-perfect.
+let _nodeSpan: HTMLSpanElement | null = null;
+let _nodeHeight: number | null = null;
+
+function ensureNodeSpan(): HTMLSpanElement | null {
+  if (typeof document === 'undefined') return null;
+  if (!_nodeSpan) {
+    _nodeSpan = document.createElement('span');
+    _nodeSpan.className = 'graph-node';
+    _nodeSpan.style.cssText += ';visibility:hidden;position:absolute;white-space:nowrap;pointer-events:none';
+    document.body.appendChild(_nodeSpan);
+    _nodeSpan.textContent = 'X';
+    _nodeHeight = _nodeSpan.offsetHeight;
+  }
+  return _nodeSpan;
 }
 
-/**
- * Measures the per-character width and horizontal padding of a
- * .graph-group-node-header element.  Uses the actual CSS class so the result
- * stays correct regardless of font, DPI, or root font-size.
- *
- * Both values are measured with a single hidden DOM element and cached for
- * the lifetime of the page.
- */
-let _cachedHeaderMetrics: { charWidth: number; padding: number } | null = null;
+function estimateNodeSize(label: string) {
+  const span = ensureNodeSpan();
+  if (!span) return { width: label.length * 7 + 26, height: 34 }; // SSR fallback
+  span.textContent = label;
+  return { width: span.offsetWidth, height: _nodeHeight ?? 34 };
+}
 
-function measureHeaderMetrics(): { charWidth: number; padding: number } {
-  if (_cachedHeaderMetrics !== null) return _cachedHeaderMetrics;
-  if (typeof document === 'undefined') return { charWidth: 7, padding: 20 }; // SSR fallback
-  const span = document.createElement('span');
-  span.className = 'graph-group-node-header';
-  span.style.cssText += ';visibility:hidden;position:absolute;white-space:nowrap;pointer-events:none';
-  document.body.appendChild(span);
-  const cs = getComputedStyle(span);
-  const padding = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
-  // Measure average char width with representative text, subtracting padding.
-  const sampleText = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.';
-  span.textContent = sampleText;
-  const charWidth = (span.offsetWidth - padding) / sampleText.length;
-  document.body.removeChild(span);
-  _cachedHeaderMetrics = { charWidth, padding };
-  return _cachedHeaderMetrics;
+// Header measurement uses average char width (only needs minimum-width constraint).
+let _headerCharWidth: number | null = null;
+let _headerPadding: number | null = null;
+const HEADER_SAMPLE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.';
+
+function ensureHeaderMetrics(): { charWidth: number; padding: number } {
+  if (_headerCharWidth !== null && _headerPadding !== null) {
+    return { charWidth: _headerCharWidth, padding: _headerPadding };
+  }
+  if (typeof document === 'undefined') return { charWidth: 7, padding: 20 };
+  const el = document.createElement('span');
+  el.className = 'graph-group-node-header';
+  el.style.cssText += ';visibility:hidden;position:absolute;white-space:nowrap;pointer-events:none';
+  document.body.appendChild(el);
+  const cs = getComputedStyle(el);
+  _headerPadding = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+  el.textContent = HEADER_SAMPLE;
+  _headerCharWidth = (el.offsetWidth - _headerPadding) / HEADER_SAMPLE.length;
+  document.body.removeChild(el);
+  return { charWidth: _headerCharWidth, padding: _headerPadding };
 }
 
 export function measureGroupHeaderWidth(label: string): number {
-  const { charWidth, padding } = measureHeaderMetrics();
+  const { charWidth, padding } = ensureHeaderMetrics();
   return Math.ceil(label.length * charWidth + padding);
 }
 
@@ -183,287 +185,72 @@ export function adjustParentDimensions(
   return cloned;
 }
 
-function pruneEdgesForLayout(edges: FlowEdge[]) {
-  const adjacency = new Map<string, Set<string>>();
-  const pruned: FlowEdge[] = [];
-
-  const createsCycle = (source: string, target: string) => {
-    if (source === target) {
-      return true;
-    }
-
-    const visited = new Set<string>();
-    const stack: string[] = [target];
-    while (stack.length > 0) {
-      const current = stack.pop()!;
-      if (current === source) {
-        return true;
-      }
-      if (visited.has(current)) {
-        continue;
-      }
-      visited.add(current);
-
-      const neighbors = adjacency.get(current);
-      if (!neighbors) {
-        continue;
-      }
-      neighbors.forEach((neighbor) => {
-        if (!visited.has(neighbor)) {
-          stack.push(neighbor);
-        }
-      });
-    }
-
-    return false;
-  };
-
-  const addAdjacency = (source: string, target: string) => {
-    let neighbors = adjacency.get(source);
-    if (!neighbors) {
-      neighbors = new Set<string>();
-      adjacency.set(source, neighbors);
-    }
-    neighbors.add(target);
-  };
-
-  edges.forEach((edge) => {
-    if (createsCycle(edge.source, edge.target)) {
-      return;
-    }
-    addAdjacency(edge.source, edge.target);
-    pruned.push(edge);
-  });
-
-  return pruned;
-}
-
 export type { HierarchyInfo };
 
-export type LayoutOptions = {
-  direction?: 'DOWN' | 'RIGHT';
-  layerSpacing?: number;
-  nodeSpacing?: number;
-  preserveExisting?: boolean;
-  positions?: Map<string, { x: number; y: number }>;
-  incremental?: boolean;
-  hierarchy?: HierarchyInfo;
-};
+// ── Custom layout adapter ─────────────────────────────────────────
 
-export type DagreLayoutOptions = Pick<LayoutOptions, 'direction' | 'layerSpacing' | 'nodeSpacing'>;
-
-function buildElkNode(
-  node: FlowNode,
-  preserveExisting: boolean,
-  positions: Map<string, { x: number; y: number }>,
-) {
-  const { width, height } = resolveNodeSize(node);
-  const existingPosition = positions.get(node.id);
-  const shouldPreserve = preserveExisting && existingPosition;
-  return {
-    id: node.id,
-    width,
-    height,
-    ...(shouldPreserve
-      ? { x: existingPosition.x, y: existingPosition.y }
-      : {}),
-    layoutOptions: shouldPreserve ? { 'elk.fixed': 'true' } : undefined,
-  };
-}
-
-function buildNestedElkChildren(
-  nodeIds: string[],
-  nodeMap: Map<string, FlowNode>,
-  hierarchy: HierarchyInfo,
-  preserveExisting: boolean,
-  positions: Map<string, { x: number; y: number }>,
-): any[] {
-  const result: any[] = [];
-  for (const id of nodeIds) {
-    const node = nodeMap.get(id);
-    if (!node) continue;
-    const children = hierarchy.parentToChildren.get(id);
-    if (children && children.size > 0) {
-      // Parent node — don't set width/height, let ELK compute from children
-      const existingPosition = positions.get(id);
-      const shouldPreserve = preserveExisting && existingPosition;
-      result.push({
-        id,
-        ...(shouldPreserve
-          ? { x: existingPosition.x, y: existingPosition.y }
-          : {}),
-        layoutOptions: {
-          ...(shouldPreserve ? { 'elk.fixed': 'true' } : {}),
-          'elk.padding': `[top=${GROUP_PAD_TOP},left=${GROUP_PAD_LEFT},bottom=${GROUP_PAD_BOTTOM},right=${GROUP_PAD_RIGHT}]`,
-          'elk.algorithm': 'layered',
-        },
-        children: buildNestedElkChildren(
-          Array.from(children),
-          nodeMap,
-          hierarchy,
-          preserveExisting,
-          positions,
-        ),
-      });
+export function layoutGraph(
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+  previousPositions: Map<string, { x: number; y: number }>,
+  hierarchy?: HierarchyInfo,
+  measuredSizes?: Map<string, { width: number; height: number }>,
+): FlowNode[] {
+  const nodeSizes = new Map<string, { width: number; height: number }>();
+  for (const n of nodes) {
+    // Prefer measured sizes from a previous render (accurate), fall back to estimates
+    const measured = measuredSizes?.get(n.id);
+    if (measured) {
+      nodeSizes.set(n.id, measured);
     } else {
-      result.push(buildElkNode(node, preserveExisting, positions));
+      const { width, height } = resolveNodeSize(n);
+      nodeSizes.set(n.id, { width, height });
     }
   }
-  return result;
-}
 
-function collectLayoutNodes(
-  elkChildren: any[],
-  layoutNodes: Map<string, any>,
-) {
-  for (const child of elkChildren) {
-    layoutNodes.set(child.id, child);
-    if (child.children) {
-      collectLayoutNodes(child.children, layoutNodes);
-    }
-  }
-}
+  const engineEdges = edges
+    .filter(e => e.source !== e.target) // self-loops handled separately by ReactFlow
+    .map(e => ({ id: e.id, source: e.source, target: e.target }));
 
-export async function layoutGraphWithElk(
-  nodes: FlowNode[],
-  edges: FlowEdge[],
-  {
-    direction = 'DOWN',
-    layerSpacing = 8,
-    nodeSpacing = 10,
-    preserveExisting = false,
-    positions = new Map<string, { x: number; y: number }>(),
-    incremental = true,
-    hierarchy,
-  }: LayoutOptions,
-) {
-  const layoutEdges = pruneEdgesForLayout(edges);
-  const resolvedLayerSpacing = layerSpacing;
-  const resolvedNodeSpacing = nodeSpacing;
-  const resolvedEdgeSpacing = 1;
-  const edgeTrackFactor = 0.5;
-
-  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
-  const hasHierarchy = hierarchy && hierarchy.childToParent.size > 0;
-
-  let elkChildren: any[];
-  if (hasHierarchy) {
-    // Build root-level node IDs (those without a parent)
-    const rootNodeIds = nodes
-      .map((n) => n.id)
-      .filter((id) => !hierarchy.childToParent.has(id));
-    elkChildren = buildNestedElkChildren(
-      rootNodeIds,
-      nodeMap,
-      hierarchy,
-      preserveExisting,
-      positions,
-    );
-  } else {
-    elkChildren = nodes.map((node) =>
-      buildElkNode(node, preserveExisting, positions),
-    );
-  }
-
-  const elkGraph = {
-    id: 'root',
-    layoutOptions: {
-      'elk.algorithm': 'layered',
-      'elk.direction': direction,
-      'elk.spacing.nodeNode': String(resolvedNodeSpacing),
-      'elk.layered.spacing.nodeNodeBetweenLayers': String(resolvedLayerSpacing),
-      'elk.layered.spacing.edgeNodeBetweenLayers': String(resolvedEdgeSpacing),
-      'elk.layered.spacing.edgeEdgeBetweenLayers': String(resolvedEdgeSpacing),
-      'elk.layered.edgeRouting.splines.mode': 'SLOPPY',
-      'elk.layered.edgeRouting.splines.sloppy.layerSpacingFactor': String(edgeTrackFactor),
-      'elk.edgeRouting': 'POLYLINE',
-      'elk.incremental': String(incremental),
-      ...(hasHierarchy
-        ? { 'elk.hierarchyHandling': 'INCLUDE_CHILDREN' }
-        : {}),
-    },
-    children: elkChildren,
-    // All edges at root level — ELK handles cross-hierarchy routing
-    edges: layoutEdges.map((edge) => ({
-      id: edge.id,
-      sources: [edge.source],
-      targets: [edge.target],
-    })),
-  };
-
-  const layout = await elk.layout(elkGraph);
-  const layoutNodes = new Map<string, any>();
-  collectLayoutNodes(layout.children ?? [], layoutNodes);
-
-  return nodes.map((node) => {
-    const layoutNode = layoutNodes.get(node.id);
-    if (!layoutNode) {
-      return node;
-    }
-    if (preserveExisting && positions.has(node.id)) {
-      return { ...node, position: positions.get(node.id)! };
-    }
-    const isParent =
-      hasHierarchy && hierarchy.parentToChildren.has(node.id);
-    const result: FlowNode = {
-      ...node,
-      position: {
-        x: layoutNode.x ?? node.position.x,
-        y: layoutNode.y ?? node.position.y,
+  const result = layoutEngine({
+    nodes: nodeSizes,
+    edges: engineEdges,
+    hierarchy: hierarchy ?? { childToParent: new Map(), parentToChildren: new Map() },
+    previousPositions,
+    options: {
+      direction: 'DOWN',
+      layerSpacing: 50,
+      nodeSpacing: 30,
+      componentGap: 80,
+      groupPadding: {
+        top: GROUP_PAD_TOP,
+        left: GROUP_PAD_LEFT,
+        right: GROUP_PAD_RIGHT,
+        bottom: GROUP_PAD_BOTTOM,
       },
-    };
-    if (isParent) {
-      result.style = {
-        ...(result.style ?? {}),
-        width: layoutNode.width,
-        height: layoutNode.height,
-      };
-    }
-    return result;
-  });
-}
-
-export async function layoutGraphWithDagre(
-  nodes: FlowNode[],
-  edges: FlowEdge[],
-  {
-    direction = 'DOWN',
-    layerSpacing = 60,
-    nodeSpacing = 30,
-  }: DagreLayoutOptions = {},
-) {
-  const layoutEdges = pruneEdgesForLayout(edges);
-  const graph = new dagre.graphlib.Graph();
-  graph.setGraph({
-    rankdir: direction === 'RIGHT' ? 'LR' : 'TB',
-    nodesep: nodeSpacing,
-    ranksep: layerSpacing,
-  });
-  graph.setDefaultEdgeLabel(() => ({}));
-
-  nodes.forEach((node) => {
-    const { width, height } = resolveNodeSize(node);
-    graph.setNode(node.id, { width, height });
+    },
   });
 
-  layoutEdges.forEach((edge) => {
-    graph.setEdge(edge.source, edge.target);
-  });
+  return nodes.map(node => {
+    const pos = result.positions.get(node.id);
+    if (!pos) return node;
 
-  dagre.layout(graph);
+    const isGroup = hierarchy?.parentToChildren.has(node.id);
+    const dim = isGroup ? result.groupDimensions.get(node.id) : undefined;
+    const labelMinWidth = isGroup ? measureGroupHeaderWidth(resolveNodeLabel(node)) : 0;
 
-  return nodes.map((node) => {
-    const layoutNode = graph.node(node.id);
-    if (!layoutNode) {
-      return node;
-    }
-    const { width, height } = resolveNodeSize(node);
     return {
       ...node,
-      position: {
-        x: layoutNode.x - width / 2,
-        y: layoutNode.y - height / 2,
-      },
+      position: pos,
+      ...(dim
+        ? {
+            style: {
+              ...(node.style ?? {}),
+              width: Math.max(dim.width, labelMinWidth),
+              height: dim.height,
+            },
+          }
+        : {}),
     };
   });
 }

--- a/src/app/lib/layout/flat_layout.ts
+++ b/src/app/lib/layout/flat_layout.ts
@@ -1,0 +1,369 @@
+/**
+ * flat_layout.ts — Flat-graph layout engine.
+ *
+ * Fresh layouts use dagre for the full layout pipeline.
+ * Incremental updates pin existing nodes and place new ones nearby.
+ * The hierarchy decomposer in hierarchy.ts calls this once per nesting level.
+ */
+
+import dagre from '@dagrejs/dagre';
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface EdgeDef {
+  id: string;
+  source: string;
+  target: string;
+}
+
+export interface FlatLayoutOptions {
+  direction: 'DOWN' | 'RIGHT';
+  layerSpacing: number;
+  nodeSpacing: number;
+  componentGap: number;
+}
+
+export interface FlatLayoutResult {
+  positions: Map<string, { x: number; y: number }>;
+  backEdgeIds: Set<string>;
+}
+
+type Pos = { x: number; y: number };
+type Size = { width: number; height: number };
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function addAdj(adj: Map<string, Set<string>>, from: string, to: string) {
+  let s = adj.get(from);
+  if (!s) { s = new Set(); adj.set(from, s); }
+  s.add(to);
+}
+
+/** DFS reachability check in an adjacency map. */
+function reachable(adj: Map<string, Set<string>>, from: string, to: string): boolean {
+  if (from === to) return true;
+  const visited = new Set<string>();
+  const stack = [from];
+  while (stack.length > 0) {
+    const cur = stack.pop()!;
+    if (cur === to) return true;
+    if (visited.has(cur)) continue;
+    visited.add(cur);
+    const ns = adj.get(cur);
+    if (ns) ns.forEach(n => { if (!visited.has(n)) stack.push(n); });
+  }
+  return false;
+}
+
+// ── DAG Construction (cycle breaking) ────────────────────────────
+
+export interface DagResult {
+  dagEdges: EdgeDef[];
+  backEdgeIds: Set<string>;
+}
+
+/**
+ * Break cycles via greedy edge insertion with sorted edges for determinism.
+ * Returns the DAG edges and the set of back-edge IDs.
+ */
+export function buildDag(nodeIds: string[], edges: EdgeDef[]): DagResult {
+  if (nodeIds.length === 0) {
+    return { dagEdges: [], backEdgeIds: new Set() };
+  }
+
+  const nodeSet = new Set(nodeIds);
+  const valid = edges.filter(e => nodeSet.has(e.source) && nodeSet.has(e.target));
+
+  // Sort edges for determinism
+  const sorted = [...valid].sort((a, b) =>
+    a.source < b.source ? -1 : a.source > b.source ? 1
+      : a.target < b.target ? -1 : a.target > b.target ? 1 : 0,
+  );
+
+  const dagEdges: EdgeDef[] = [];
+  const backEdgeIds = new Set<string>();
+  const dagAdj = new Map<string, Set<string>>();
+
+  for (const e of sorted) {
+    if (e.source === e.target) { backEdgeIds.add(e.id); continue; }
+    if (!reachable(dagAdj, e.target, e.source)) {
+      dagEdges.push(e); addAdj(dagAdj, e.source, e.target);
+    } else {
+      backEdgeIds.add(e.id);
+    }
+  }
+
+  return { dagEdges, backEdgeIds };
+}
+
+// ── Fresh layout via dagre ───────────────────────────────────────
+
+export function freshLayout(
+  nodeIds: string[],
+  nodeSizes: Map<string, Size>,
+  dagEdges: EdgeDef[],
+  options: Pick<FlatLayoutOptions, 'layerSpacing' | 'nodeSpacing'>,
+): Map<string, Pos> {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({ rankdir: 'TB', nodesep: options.nodeSpacing, ranksep: options.layerSpacing });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  for (const id of nodeIds) {
+    const s = nodeSizes.get(id) ?? { width: 180, height: 40 };
+    g.setNode(id, { width: s.width, height: s.height });
+  }
+  for (const e of dagEdges) {
+    g.setEdge(e.source, e.target);
+  }
+
+  dagre.layout(g);
+
+  const positions = new Map<string, Pos>();
+  for (const id of nodeIds) {
+    const n = g.node(id);
+    if (!n) continue;
+    const s = nodeSizes.get(id) ?? { width: 180, height: 40 };
+    positions.set(id, { x: n.x - s.width / 2, y: n.y - s.height / 2 });
+  }
+  return positions;
+}
+
+// ── Incremental layout: pin existing, place new nearby ───────────
+
+export function placeNewNodes(
+  nodeIds: string[],
+  nodeSizes: Map<string, Size>,
+  edges: EdgeDef[],
+  previousPositions: Map<string, Pos>,
+  options: Pick<FlatLayoutOptions, 'layerSpacing' | 'nodeSpacing'>,
+): Map<string, Pos> {
+  const positions = new Map<string, Pos>();
+  const { layerSpacing, nodeSpacing } = options;
+
+  // 1. Pin existing nodes
+  for (const id of nodeIds) {
+    const prev = previousPositions.get(id);
+    if (prev) positions.set(id, prev);
+  }
+
+  // Build bidirectional adjacency + directed parent/child sets
+  const neighbors = new Map<string, string[]>();
+  const parents = new Map<string, string[]>();   // nodes with edges TO this node
+  const children = new Map<string, string[]>();  // nodes with edges FROM this node
+  for (const id of nodeIds) { neighbors.set(id, []); parents.set(id, []); children.set(id, []); }
+  const nodeSet = new Set(nodeIds);
+  for (const e of edges) {
+    if (!nodeSet.has(e.source) || !nodeSet.has(e.target)) continue;
+    neighbors.get(e.source)!.push(e.target);
+    neighbors.get(e.target)!.push(e.source);
+    children.get(e.source)!.push(e.target);
+    parents.get(e.target)!.push(e.source);
+  }
+
+  // 2. Place new nodes via BFS from positioned nodes
+  const placed = new Set<string>();
+  const queue: string[] = [];
+  for (const id of nodeIds) {
+    if (positions.has(id)) { placed.add(id); queue.push(id); }
+  }
+
+  let head = 0;
+  while (head < queue.length) {
+    const cur = queue[head++];
+    for (const nbr of neighbors.get(cur) ?? []) {
+      if (placed.has(nbr)) continue;
+      placed.add(nbr);
+      queue.push(nbr);
+
+      const w = nodeSizes.get(nbr)?.width ?? 180;
+      const h = nodeSizes.get(nbr)?.height ?? 40;
+      const posNbrs = (neighbors.get(nbr) ?? []).filter(n => positions.has(n));
+      if (posNbrs.length > 0) {
+        // X: median of positioned neighbors' centers
+        const xs = posNbrs.map(n => {
+          const p = positions.get(n)!;
+          return p.x + (nodeSizes.get(n)?.width ?? 180) / 2;
+        });
+        xs.sort((a, b) => a - b);
+        let x = xs[Math.floor(xs.length / 2)] - w / 2;
+
+        // Y: use directed edges to determine above vs below.
+        // Positioned parents → place below them.  Positioned children → place above them.
+        const posParents = (parents.get(nbr) ?? []).filter(n => positions.has(n));
+        const posChildren = (children.get(nbr) ?? []).filter(n => positions.has(n));
+
+        let y: number;
+        if (posParents.length > 0 && posChildren.length === 0) {
+          // Has parents only → place below the lowest parent
+          let maxBottom = -Infinity;
+          for (const n of posParents) {
+            const p = positions.get(n)!;
+            maxBottom = Math.max(maxBottom, p.y + (nodeSizes.get(n)?.height ?? 40));
+          }
+          y = maxBottom + layerSpacing;
+        } else if (posChildren.length > 0 && posParents.length === 0) {
+          // Has children only → place above the highest child
+          let minTop = Infinity;
+          for (const n of posChildren) {
+            minTop = Math.min(minTop, positions.get(n)!.y);
+          }
+          y = minTop - h - layerSpacing;
+        } else {
+          // Mixed or fallback → place below the lowest neighbor
+          let maxBottom = -Infinity;
+          for (const n of posNbrs) {
+            const p = positions.get(n)!;
+            maxBottom = Math.max(maxBottom, p.y + (nodeSizes.get(n)?.height ?? 40));
+          }
+          y = maxBottom + layerSpacing;
+        }
+
+        // Resolve overlaps: find max right edge of all overlapping nodes in one pass,
+        // repeat until x stops changing.  Bounded to prevent infinite loops.
+        const maxIter = positions.size + 1;
+        for (let iter = 0; iter < maxIter; iter++) {
+          let newX = x;
+          positions.forEach((op, oid) => {
+            if (oid === nbr) return;
+            const ow = nodeSizes.get(oid)?.width ?? 180;
+            const oh = nodeSizes.get(oid)?.height ?? 40;
+            const xOverlap = newX < op.x + ow + nodeSpacing && newX + w + nodeSpacing > op.x;
+            const yOverlap = y < op.y + oh && y + h > op.y;
+            if (xOverlap && yOverlap) newX = Math.max(newX, op.x + ow + nodeSpacing);
+          });
+          if (newX === x) break;
+          x = newX;
+        }
+
+        positions.set(nbr, { x, y });
+      } else {
+        positions.set(nbr, { x: 0, y: 0 });
+      }
+    }
+  }
+
+  // 3. Handle isolated new nodes
+  for (const id of nodeIds) {
+    if (!positions.has(id)) {
+      let maxRight = 0;
+      positions.forEach((p, pid) => {
+        maxRight = Math.max(maxRight, p.x + (nodeSizes.get(pid)?.width ?? 180));
+      });
+      positions.set(id, { x: maxRight + nodeSpacing, y: 0 });
+    }
+  }
+
+  return positions;
+}
+
+// ── Connected Components ─────────────────────────────────────────
+
+export function findComponents(nodeIds: string[], edges: EdgeDef[]): string[][] {
+  if (nodeIds.length === 0) return [];
+  const parent = new Map<string, string>();
+  const rank = new Map<string, number>();
+  for (const id of nodeIds) { parent.set(id, id); rank.set(id, 0); }
+
+  function find(x: string): string {
+    while (parent.get(x) !== x) { parent.set(x, parent.get(parent.get(x)!)!); x = parent.get(x)!; }
+    return x;
+  }
+  function union(a: string, b: string) {
+    let ra = find(a), rb = find(b);
+    if (ra === rb) return;
+    if (rank.get(ra)! < rank.get(rb)!) [ra, rb] = [rb, ra];
+    parent.set(rb, ra);
+    if (rank.get(ra) === rank.get(rb)) rank.set(ra, rank.get(ra)! + 1);
+  }
+
+  const ns = new Set(nodeIds);
+  for (const e of edges) { if (ns.has(e.source) && ns.has(e.target)) union(e.source, e.target); }
+
+  const groups = new Map<string, string[]>();
+  for (const id of nodeIds) {
+    const r = find(id);
+    let arr = groups.get(r);
+    if (!arr) { arr = []; groups.set(r, arr); }
+    arr.push(id);
+  }
+  return Array.from(groups.values()).sort((a, b) => b.length - a.length);
+}
+
+// ── Main Entry Point ─────────────────────────────────────────────
+
+export function layoutFlat(
+  nodes: Map<string, Size>,
+  edges: EdgeDef[],
+  previousPositions: Map<string, Pos>,
+  options: FlatLayoutOptions,
+): FlatLayoutResult {
+  const nodeIds = Array.from(nodes.keys());
+  if (nodeIds.length === 0) return { positions: new Map(), backEdgeIds: new Set() };
+
+  // For RIGHT direction: swap width↔height and x↔y, compute as DOWN, swap back
+  const isRight = options.direction === 'RIGHT';
+  const effectiveNodes = isRight
+    ? new Map(Array.from(nodes).map(([id, s]) => [id, { width: s.height, height: s.width }] as [string, Size]))
+    : nodes;
+  const effectivePrev = isRight
+    ? new Map(Array.from(previousPositions).map(([id, p]) => [id, { x: p.y, y: p.x }] as [string, Pos]))
+    : previousPositions;
+  const effectiveOpts = { ...options, direction: 'DOWN' as const };
+
+  const components = findComponents(nodeIds, edges);
+  const allPos = new Map<string, Pos>();
+  const allBack = new Set<string>();
+
+  interface CompResult { positions: Map<string, Pos>; anchored: boolean; right: number }
+  const results: CompResult[] = [];
+
+  for (const compIds of components) {
+    const compSet = new Set(compIds);
+    const compEdges = edges.filter(e => compSet.has(e.source) && compSet.has(e.target));
+    const compSizes = new Map<string, Size>();
+    for (const id of compIds) compSizes.set(id, effectiveNodes.get(id)!);
+
+    const { dagEdges, backEdgeIds } = buildDag(compIds, compEdges);
+    backEdgeIds.forEach(id => allBack.add(id));
+
+    const anchored = compIds.some(id => effectivePrev.has(id));
+
+    const positions = anchored
+      ? placeNewNodes(compIds, compSizes, compEdges, effectivePrev, effectiveOpts)
+      : freshLayout(compIds, compSizes, dagEdges, effectiveOpts);
+
+    let right = -Infinity;
+    positions.forEach((p, id) => { right = Math.max(right, p.x + (compSizes.get(id)?.width ?? 0)); });
+    results.push({ positions, anchored, right });
+  }
+
+  // Arrange components: anchored first, then floating to the right
+  let maxRight = -Infinity;
+  let minAnchoredY = Infinity;
+  for (const r of results) {
+    if (r.anchored) {
+      r.positions.forEach((p, id) => {
+        allPos.set(id, p);
+        minAnchoredY = Math.min(minAnchoredY, p.y);
+      });
+      maxRight = Math.max(maxRight, r.right);
+    }
+  }
+  let curX = Number.isFinite(maxRight) ? maxRight + effectiveOpts.componentGap : 0;
+  for (const r of results) {
+    if (!r.anchored) {
+      let minX = Infinity, minY = Infinity;
+      r.positions.forEach(p => { minX = Math.min(minX, p.x); minY = Math.min(minY, p.y); });
+      const offX = curX - (Number.isFinite(minX) ? minX : 0);
+      const offY = Number.isFinite(minAnchoredY) ? minAnchoredY - (Number.isFinite(minY) ? minY : 0) : 0;
+      r.positions.forEach((p, id) => allPos.set(id, { x: p.x + offX, y: p.y + offY }));
+      curX = r.right + offX + effectiveOpts.componentGap;
+    }
+  }
+
+  if (isRight) {
+    allPos.forEach((p, id) => allPos.set(id, { x: p.y, y: p.x }));
+  }
+
+  return { positions: allPos, backEdgeIds: allBack };
+}

--- a/src/app/lib/layout/hierarchy.ts
+++ b/src/app/lib/layout/hierarchy.ts
@@ -1,0 +1,211 @@
+/**
+ * hierarchy.ts — Nesting decomposer for hierarchical graph layout.
+ *
+ * Orchestrates bottom-up calls to a flat layout engine: processes deepest
+ * groups first, computes group dimensions from children bounds, lifts
+ * cross-group edges to parent level, and converts positions between
+ * group-relative and absolute coordinate systems.
+ *
+ * The flat backend is pluggable — passed as `flatLayoutFn`.
+ */
+
+import type { EdgeDef, FlatLayoutOptions, FlatLayoutResult } from './flat_layout';
+
+// ── Types ─────────────────────────────────────────────────────────
+
+export interface HierarchyInfo {
+  childToParent: Map<string, string>;
+  parentToChildren: Map<string, Set<string>>;
+}
+
+export interface GroupPadding {
+  top: number;
+  left: number;
+  right: number;
+  bottom: number;
+}
+
+type Pos = { x: number; y: number };
+type Size = { width: number; height: number };
+
+export type FlatLayoutFn = (
+  nodes: Map<string, Size>,
+  edges: EdgeDef[],
+  previousPositions: Map<string, Pos>,
+  options: FlatLayoutOptions,
+) => FlatLayoutResult;
+
+export interface DecomposeResult {
+  positions: Map<string, Pos>;
+  groupDimensions: Map<string, Size>;
+  backEdgeIds: Set<string>;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+/** Nesting depth: 0 for top-level, 1 for children of top-level groups, etc. */
+export function computeNestingDepth(nodeId: string, hierarchy: HierarchyInfo): number {
+  let depth = 0;
+  let cur = hierarchy.childToParent.get(nodeId);
+  while (cur) { depth++; cur = hierarchy.childToParent.get(cur); }
+  return depth;
+}
+
+/**
+ * Compute group bounding box from children positions + padding.
+ *
+ * Returns the group dimensions and the shift needed to move children
+ * so their bounding box starts at `(padding.left, padding.top)`.
+ */
+export function computeGroupBounds(
+  positions: Map<string, Pos>,
+  sizes: Map<string, Size>,
+  padding: GroupPadding,
+): { width: number; height: number; shiftX: number; shiftY: number } {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  positions.forEach((pos, id) => {
+    const s = sizes.get(id) ?? { width: 180, height: 40 };
+    minX = Math.min(minX, pos.x);
+    minY = Math.min(minY, pos.y);
+    maxX = Math.max(maxX, pos.x + s.width);
+    maxY = Math.max(maxY, pos.y + s.height);
+  });
+  if (!Number.isFinite(minX)) {
+    return { width: padding.left + padding.right, height: padding.top + padding.bottom, shiftX: 0, shiftY: 0 };
+  }
+  const shiftX = padding.left - minX;
+  const shiftY = padding.top - minY;
+  return {
+    width: (maxX - minX) + padding.left + padding.right,
+    height: (maxY - minY) + padding.top + padding.bottom,
+    shiftX,
+    shiftY,
+  };
+}
+
+/**
+ * Walk `nodeId` up the hierarchy until landing on a node in `participants`.
+ * Returns undefined if the node can't reach any participant.
+ */
+function walkToParticipant(
+  nodeId: string,
+  hierarchy: HierarchyInfo,
+  participants: Set<string>,
+): string | undefined {
+  let cur: string | undefined = nodeId;
+  while (cur !== undefined) {
+    if (participants.has(cur)) return cur;
+    cur = hierarchy.childToParent.get(cur);
+  }
+  return undefined;
+}
+
+/**
+ * Project all edges onto a set of participants by walking each endpoint
+ * up the hierarchy.  Intra-group edges (both endpoints lift to the same
+ * participant) are dropped.  Duplicate source→target pairs are merged.
+ *
+ * Direct edges between participants keep their original ID (important for
+ * back-edge tracking).  Lifted edges get synthetic IDs prefixed `lifted:`.
+ */
+function getEdgesForLevel(
+  edges: EdgeDef[],
+  hierarchy: HierarchyInfo,
+  participants: Set<string>,
+): EdgeDef[] {
+  const result: EdgeDef[] = [];
+  const seen = new Set<string>();
+  for (const e of edges) {
+    const es = walkToParticipant(e.source, hierarchy, participants);
+    const et = walkToParticipant(e.target, hierarchy, participants);
+    if (!es || !et || es === et) continue;
+    const key = `${es}\0${et}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const isLifted = es !== e.source || et !== e.target;
+    result.push({ id: isLifted ? `lifted:${es}:${et}` : e.id, source: es, target: et });
+  }
+  return result;
+}
+
+// ── Main Decomposer ──────────────────────────────────────────────
+
+export function decomposeAndLayout(
+  nodes: Map<string, Size>,
+  edges: EdgeDef[],
+  hierarchy: HierarchyInfo,
+  previousPositions: Map<string, Pos>,
+  options: FlatLayoutOptions & { groupPadding: GroupPadding },
+  flatLayoutFn: FlatLayoutFn,
+): DecomposeResult {
+  const positions = new Map<string, Pos>();
+  const groupDims = new Map<string, Size>();
+  const backEdgeIds = new Set<string>();
+
+  // Sort groups deepest-first
+  const groupIds = Array.from(hierarchy.parentToChildren.keys());
+  groupIds.sort((a, b) => computeNestingDepth(b, hierarchy) - computeNestingDepth(a, hierarchy));
+
+  // ── Bottom-up: process each group's children ───────────────────
+
+  for (const gid of groupIds) {
+    const childSet = hierarchy.parentToChildren.get(gid)!;
+    if (childSet.size === 0) continue;
+    const participants = new Set(Array.from(childSet));
+
+    // Node sizes: computed group dims for sub-groups, input for leaves
+    const childSizes = new Map<string, Size>();
+    participants.forEach(cid => {
+      childSizes.set(cid, groupDims.get(cid) ?? nodes.get(cid) ?? { width: 180, height: 40 });
+    });
+
+    const levelEdges = getEdgesForLevel(edges, hierarchy, participants);
+
+    // Previous positions for children (group-relative, matching positionsRef convention)
+    const childPrev = new Map<string, Pos>();
+    participants.forEach(cid => {
+      const p = previousPositions.get(cid);
+      if (p) childPrev.set(cid, p);
+    });
+
+    const result = flatLayoutFn(childSizes, levelEdges, childPrev, options);
+
+    // Collect non-lifted back edges
+    result.backEdgeIds.forEach(id => {
+      if (!id.startsWith('lifted:')) backEdgeIds.add(id);
+    });
+
+    // Shift children so bbox starts at (padLeft, padTop); compute group size
+    const bounds = computeGroupBounds(result.positions, childSizes, options.groupPadding);
+    groupDims.set(gid, { width: bounds.width, height: bounds.height });
+
+    result.positions.forEach((pos, id) => {
+      positions.set(id, { x: pos.x + bounds.shiftX, y: pos.y + bounds.shiftY });
+    });
+  }
+
+  // ── Top level ──────────────────────────────────────────────────
+
+  const topIds = Array.from(nodes.keys()).filter(id => !hierarchy.childToParent.has(id));
+  const topSizes = new Map<string, Size>();
+  for (const id of topIds) {
+    topSizes.set(id, groupDims.get(id) ?? nodes.get(id) ?? { width: 180, height: 40 });
+  }
+
+  const topParticipants = new Set(topIds);
+  const topEdges = getEdgesForLevel(edges, hierarchy, topParticipants);
+
+  const topPrev = new Map<string, Pos>();
+  for (const id of topIds) {
+    const p = previousPositions.get(id);
+    if (p) topPrev.set(id, p);
+  }
+
+  const topResult = flatLayoutFn(topSizes, topEdges, topPrev, options);
+  topResult.backEdgeIds.forEach(id => {
+    if (!id.startsWith('lifted:')) backEdgeIds.add(id);
+  });
+  topResult.positions.forEach((pos, id) => positions.set(id, pos));
+
+  return { positions, groupDimensions: groupDims, backEdgeIds };
+}

--- a/src/app/lib/layout/index.ts
+++ b/src/app/lib/layout/index.ts
@@ -1,0 +1,80 @@
+/**
+ * layout/index.ts — Public API for the graph layout engine.
+ *
+ * Detects whether the graph has hierarchy and delegates accordingly:
+ * flat graphs go directly to the flat layout engine; hierarchical graphs
+ * go through the nesting decomposer which calls it per level.
+ */
+
+import { layoutFlat } from './flat_layout';
+import { decomposeAndLayout } from './hierarchy';
+import type { GroupPadding, HierarchyInfo } from './hierarchy';
+import type { EdgeDef } from './flat_layout';
+
+// ── Public Types ──────────────────────────────────────────────────
+
+export type { EdgeDef, FlatLayoutOptions } from './flat_layout';
+export type { GroupPadding, HierarchyInfo } from './hierarchy';
+
+export interface LayoutInput {
+  nodes: Map<string, { width: number; height: number }>;
+  edges: EdgeDef[];
+  hierarchy: HierarchyInfo;
+  previousPositions: Map<string, { x: number; y: number }>;
+  options: {
+    direction: 'DOWN' | 'RIGHT';
+    layerSpacing: number;
+    nodeSpacing: number;
+    componentGap: number;
+    groupPadding: GroupPadding;
+  };
+}
+
+export interface LayoutResult {
+  /** Positions relative to parent (or absolute if no parent). */
+  positions: Map<string, { x: number; y: number }>;
+  /** Computed dimensions for group nodes. */
+  groupDimensions: Map<string, { width: number; height: number }>;
+  /** Edge IDs identified as back-edges during DAG construction. */
+  backEdgeIds: Set<string>;
+}
+
+// ── Entry Point ──────────────────────────────────────────────────
+
+export function layoutGraph(input: LayoutInput): LayoutResult {
+  const hasHierarchy = input.hierarchy.childToParent.size > 0;
+
+  if (!hasHierarchy) {
+    const result = layoutFlat(
+      input.nodes,
+      input.edges,
+      input.previousPositions,
+      {
+        direction: input.options.direction,
+        layerSpacing: input.options.layerSpacing,
+        nodeSpacing: input.options.nodeSpacing,
+        componentGap: input.options.componentGap,
+      },
+    );
+    return {
+      positions: result.positions,
+      groupDimensions: new Map(),
+      backEdgeIds: result.backEdgeIds,
+    };
+  }
+
+  return decomposeAndLayout(
+    input.nodes,
+    input.edges,
+    input.hierarchy,
+    input.previousPositions,
+    {
+      direction: input.options.direction,
+      layerSpacing: input.options.layerSpacing,
+      nodeSpacing: input.options.nodeSpacing,
+      componentGap: input.options.componentGap,
+      groupPadding: input.options.groupPadding,
+    },
+    layoutFlat,
+  );
+}

--- a/src/app/lib/layout/layout.test.ts
+++ b/src/app/lib/layout/layout.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect } from 'vitest';
+import { buildDag, findComponents, placeNewNodes, layoutFlat } from './flat_layout';
+import type { EdgeDef, FlatLayoutOptions } from './flat_layout';
+import { computeGroupBounds, decomposeAndLayout, computeNestingDepth } from './hierarchy';
+import type { HierarchyInfo, GroupPadding } from './hierarchy';
+import { layoutGraph } from './index';
+
+// ── Helpers ───────────────────────────────────────────────────────
+
+function edge(source: string, target: string, id?: string): EdgeDef {
+  return { id: id ?? `${source}->${target}`, source, target };
+}
+
+function sizes(...ids: string[]): Map<string, { width: number; height: number }> {
+  const m = new Map<string, { width: number; height: number }>();
+  for (const id of ids) m.set(id, { width: 100, height: 40 });
+  return m;
+}
+
+const defaultOpts: FlatLayoutOptions = {
+  direction: 'DOWN',
+  layerSpacing: 50,
+  nodeSpacing: 30,
+  componentGap: 80,
+};
+
+const defaultPad: GroupPadding = { top: 40, left: 10, right: 10, bottom: 10 };
+
+function noOverlaps(
+  positions: Map<string, { x: number; y: number }>,
+  nodeSizes: Map<string, { width: number; height: number }>,
+  minSpacing = 0,
+): boolean {
+  const entries = Array.from(positions.entries());
+  for (let i = 0; i < entries.length; i++) {
+    for (let j = i + 1; j < entries.length; j++) {
+      const [idA, posA] = entries[i];
+      const [idB, posB] = entries[j];
+      const sA = nodeSizes.get(idA) ?? { width: 100, height: 40 };
+      const sB = nodeSizes.get(idB) ?? { width: 100, height: 40 };
+      // Full 2D AABB overlap check (spacing applied to both axes)
+      const xOverlap = posA.x < posB.x + sB.width + minSpacing &&
+                        posA.x + sA.width + minSpacing > posB.x;
+      const yOverlap = posA.y < posB.y + sB.height + minSpacing &&
+                        posA.y + sA.height + minSpacing > posB.y;
+      if (xOverlap && yOverlap) return false;
+    }
+  }
+  return true;
+}
+
+// ── DAG Construction ─────────────────────────────────────────────
+
+describe('buildDag', () => {
+  it('keeps all edges in an acyclic graph', () => {
+    const r = buildDag(['a', 'b', 'c'], [edge('a', 'b'), edge('b', 'c')]);
+    expect(r.backEdgeIds.size).toBe(0);
+    expect(r.dagEdges.length).toBe(2);
+  });
+
+  it('handles a diamond shape without back edges', () => {
+    const r = buildDag(
+      ['a', 'b', 'c', 'd'],
+      [edge('a', 'b'), edge('a', 'c'), edge('b', 'd'), edge('c', 'd')],
+    );
+    expect(r.backEdgeIds.size).toBe(0);
+    expect(r.dagEdges.length).toBe(4);
+  });
+
+  it('detects back edges in a cycle', () => {
+    const r = buildDag(['a', 'b', 'c'], [
+      edge('a', 'b'), edge('b', 'c'), edge('c', 'a', 'back'),
+    ]);
+    expect(r.backEdgeIds.has('back')).toBe(true);
+    expect(r.dagEdges.length).toBe(2);
+  });
+
+  it('classifies self-loops as back edges', () => {
+    const r = buildDag(['a'], [edge('a', 'a', 'self')]);
+    expect(r.backEdgeIds.has('self')).toBe(true);
+    expect(r.dagEdges.length).toBe(0);
+  });
+
+  it('is deterministic across repeated calls', () => {
+    const args: [string[], EdgeDef[]] = [
+      ['c', 'a', 'b'],
+      [edge('a', 'b'), edge('b', 'c'), edge('c', 'a', 'back')],
+    ];
+    const r1 = buildDag(...args);
+    const r2 = buildDag(...args);
+    expect(r1.dagEdges.map(e => e.id)).toEqual(r2.dagEdges.map(e => e.id));
+    expect(Array.from(r1.backEdgeIds)).toEqual(Array.from(r2.backEdgeIds));
+  });
+
+  it('handles a graph with no edges', () => {
+    const r = buildDag(['a', 'b'], []);
+    expect(r.dagEdges.length).toBe(0);
+    expect(r.backEdgeIds.size).toBe(0);
+  });
+
+  it('picks a root when all nodes are in cycles', () => {
+    const r = buildDag(['a', 'b'], [edge('a', 'b'), edge('b', 'a')]);
+    expect(r.dagEdges.length).toBe(1);
+    expect(r.backEdgeIds.size).toBe(1);
+  });
+});
+
+// ── Incremental placement ────────────────────────────────────────
+
+describe('placeNewNodes', () => {
+  it('pins existing nodes at their previous positions', () => {
+    const s = sizes('a', 'b');
+    const prev = new Map([['a', { x: 200, y: 55 }]]);
+    const pos = placeNewNodes(['a', 'b'], s, [edge('a', 'b')], prev, defaultOpts);
+    expect(pos.get('a')!.x).toBe(200);
+    expect(pos.get('a')!.y).toBe(55);
+  });
+
+  it('places new node near its positioned neighbor', () => {
+    const s = sizes('a', 'b');
+    const prev = new Map([['a', { x: 100, y: 50 }]]);
+    const pos = placeNewNodes(['a', 'b'], s, [edge('a', 'b')], prev, defaultOpts);
+    // b should be near a horizontally (centered under a)
+    const aCenterX = 100 + 50;
+    const bCenterX = pos.get('b')!.x + 50;
+    expect(Math.abs(bCenterX - aCenterX)).toBeLessThan(5);
+    // b should be below a
+    expect(pos.get('b')!.y).toBeGreaterThan(pos.get('a')!.y);
+  });
+
+  it('handles isolated new node', () => {
+    const s = sizes('a', 'b');
+    const prev = new Map([['a', { x: 100, y: 50 }]]);
+    // b has no edges — isolated
+    const pos = placeNewNodes(['a', 'b'], s, [], prev, defaultOpts);
+    expect(pos.has('b')).toBe(true);
+  });
+
+  it('resolves overlaps when new node must shift past multiple existing nodes', () => {
+    const s = sizes('a', 'b', 'c', 'd', 'p');
+    const prev = new Map<string, { x: number; y: number }>([
+      ['a', { x: 0, y: 90 }],
+      ['b', { x: 130, y: 90 }],
+      ['c', { x: 260, y: 90 }],
+      ['p', { x: 130, y: 0 }],
+    ]);
+    // d connects to p — its idealX lands on top of a,b,c row, must shift past them
+    const pos = placeNewNodes(
+      ['a', 'b', 'c', 'd', 'p'], s,
+      [edge('p', 'a'), edge('p', 'b'), edge('p', 'c'), edge('p', 'd')],
+      prev, defaultOpts,
+    );
+    expect(noOverlaps(pos, s, 0)).toBe(true);
+  });
+
+  it('places new parent above existing children', () => {
+    const s = sizes('parent', 'child');
+    const prev = new Map([['child', { x: 100, y: 200 }]]);
+    // parent → child: parent should be placed ABOVE child
+    const pos = placeNewNodes(['parent', 'child'], s, [edge('parent', 'child')], prev, defaultOpts);
+    expect(pos.get('parent')!.y).toBeLessThan(pos.get('child')!.y);
+  });
+});
+
+// ── Dagre fresh layout (centering) ───────────────────────────────
+
+describe('dagre fresh layout', () => {
+  function center(pos: Map<string, { x: number; y: number }>, id: string, s: Map<string, { width: number; height: number }>): number {
+    return pos.get(id)!.x + (s.get(id)?.width ?? 100) / 2;
+  }
+
+  it('parent centered over children', () => {
+    const s = sizes('a', 'b', 'c');
+    const edges = [edge('a', 'b'), edge('a', 'c')];
+    const { positions } = layoutFlat(s, edges, new Map(), defaultOpts);
+    const aC = center(positions, 'a', s);
+    const childMid = (center(positions, 'b', s) + center(positions, 'c', s)) / 2;
+    expect(Math.abs(aC - childMid)).toBeLessThan(5);
+  });
+
+  it('subtrees stay grouped: C directly above G', () => {
+    // A→{B,C}, B→{D,E,F}, C→G
+    const s = sizes('a', 'b', 'c', 'd', 'e', 'f', 'g');
+    const edges = [
+      edge('a', 'b'), edge('a', 'c'),
+      edge('b', 'd'), edge('b', 'e'), edge('b', 'f'),
+      edge('c', 'g'),
+    ];
+    const { positions } = layoutFlat(s, edges, new Map(), defaultOpts);
+    expect(Math.abs(center(positions, 'c', s) - center(positions, 'g', s))).toBeLessThan(5);
+    expect(noOverlaps(positions, s)).toBe(true);
+  });
+
+  it('no overlaps in complex graph', () => {
+    const s = sizes('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h');
+    const edges = [
+      edge('a', 'b'), edge('a', 'c'),
+      edge('b', 'd'), edge('d', 'e'), edge('d', 'f'), edge('d', 'g'),
+      edge('c', 'h'),
+    ];
+    const { positions } = layoutFlat(s, edges, new Map(), defaultOpts);
+    expect(noOverlaps(positions, s)).toBe(true);
+  });
+});
+
+// ── Connected Components ─────────────────────────────────────────
+
+describe('findComponents', () => {
+  it('finds separate components', () => {
+    const comps = findComponents(['a', 'b', 'c', 'd'], [edge('a', 'b'), edge('c', 'd')]);
+    expect(comps.length).toBe(2);
+    expect(comps[0].length).toBe(2);
+    expect(comps[1].length).toBe(2);
+  });
+
+  it('merges connected nodes', () => {
+    const comps = findComponents(['a', 'b', 'c'], [edge('a', 'b'), edge('b', 'c')]);
+    expect(comps.length).toBe(1);
+    expect(comps[0].length).toBe(3);
+  });
+
+  it('handles isolated nodes', () => {
+    const comps = findComponents(['a', 'b'], []);
+    expect(comps.length).toBe(2);
+  });
+});
+
+// ── layoutFlat (full pipeline) ───────────────────────────────────
+
+describe('layoutFlat', () => {
+  it('handles empty graph', () => {
+    const { positions } = layoutFlat(new Map(), [], new Map(), defaultOpts);
+    expect(positions.size).toBe(0);
+  });
+
+  it('handles single node', () => {
+    const s = sizes('a');
+    const { positions } = layoutFlat(s, [], new Map(), defaultOpts);
+    expect(positions.size).toBe(1);
+    expect(positions.has('a')).toBe(true);
+  });
+
+  it('ignores edges referencing non-existent nodes', () => {
+    const s = sizes('a', 'b');
+    const { positions } = layoutFlat(s, [edge('a', 'b'), edge('a', 'ghost')], new Map(), defaultOpts);
+    expect(positions.size).toBe(2);
+    expect(noOverlaps(positions, s)).toBe(true);
+  });
+
+  it('lays out a simple graph with no overlaps', () => {
+    const s = sizes('a', 'b', 'c');
+    const edges = [edge('a', 'b'), edge('a', 'c')];
+    const { positions } = layoutFlat(s, edges, new Map(), defaultOpts);
+    expect(positions.size).toBe(3);
+    expect(noOverlaps(positions, s)).toBe(true);
+    // a should be above b and c
+    expect(positions.get('a')!.y).toBeLessThan(positions.get('b')!.y);
+    expect(positions.get('a')!.y).toBeLessThan(positions.get('c')!.y);
+  });
+
+  it('arranges disconnected components without overlap', () => {
+    const s = sizes('a', 'b', 'c', 'd');
+    const edges = [edge('a', 'b'), edge('c', 'd')];
+    const { positions } = layoutFlat(s, edges, new Map(), defaultOpts);
+    expect(positions.size).toBe(4);
+    expect(noOverlaps(positions, s)).toBe(true);
+  });
+
+  it('supports RIGHT direction', () => {
+    const s = sizes('a', 'b');
+    const edges = [edge('a', 'b')];
+    const { positions } = layoutFlat(s, edges, new Map(), { ...defaultOpts, direction: 'RIGHT' });
+    // In RIGHT mode, b should be to the right of a
+    expect(positions.get('b')!.x).toBeGreaterThan(positions.get('a')!.x);
+  });
+
+  it('preserves positions for pinned nodes', () => {
+    const s = sizes('a', 'b', 'c');
+    const edges = [edge('a', 'b')];
+    const prev = new Map([
+      ['a', { x: 50, y: 0 }],
+      ['b', { x: 50, y: 90 }],
+    ]);
+    const { positions } = layoutFlat(s, edges, prev, defaultOpts);
+    // c is new, a and b should keep their X
+    expect(positions.get('a')!.x).toBe(50);
+    expect(positions.get('b')!.x).toBe(50);
+  });
+});
+
+// ── Hierarchy ────────────────────────────────────────────────────
+
+describe('hierarchy', () => {
+  it('computeNestingDepth returns correct depths', () => {
+    const h: HierarchyInfo = {
+      childToParent: new Map([['b', 'a'], ['c', 'b']]),
+      parentToChildren: new Map([['a', new Set(['b'])], ['b', new Set(['c'])]]),
+    };
+    expect(computeNestingDepth('a', h)).toBe(0);
+    expect(computeNestingDepth('b', h)).toBe(1);
+    expect(computeNestingDepth('c', h)).toBe(2);
+  });
+
+  it('computeGroupBounds computes correctly', () => {
+    const positions = new Map([
+      ['a', { x: 10, y: 20 }],
+      ['b', { x: 50, y: 80 }],
+    ]);
+    const nodeSizes = new Map([
+      ['a', { width: 100, height: 40 }],
+      ['b', { width: 80, height: 40 }],
+    ]);
+    const bounds = computeGroupBounds(positions, nodeSizes, defaultPad);
+    // minX=10, maxX=130, minY=20, maxY=120
+    // shiftX = 10 - 10 = 0, shiftY = 40 - 20 = 20
+    expect(bounds.shiftX).toBe(0);
+    expect(bounds.shiftY).toBe(20);
+    // width = (130-10) + 10 + 10 = 140, height = (120-20) + 40 + 10 = 150
+    expect(bounds.width).toBe(140);
+    expect(bounds.height).toBe(150);
+  });
+
+  it('decomposeAndLayout sizes groups correctly', () => {
+    const h: HierarchyInfo = {
+      childToParent: new Map([['b', 'g'], ['c', 'g']]),
+      parentToChildren: new Map([['g', new Set(['b', 'c'])]]),
+    };
+    const s = new Map<string, { width: number; height: number }>([
+      ['g', { width: 100, height: 40 }],
+      ['b', { width: 100, height: 40 }],
+      ['c', { width: 100, height: 40 }],
+    ]);
+    const result = decomposeAndLayout(
+      s, [], h, new Map(),
+      { ...defaultOpts, groupPadding: defaultPad },
+      layoutFlat,
+    );
+    expect(result.groupDimensions.has('g')).toBe(true);
+    const dim = result.groupDimensions.get('g')!;
+    expect(dim.width).toBeGreaterThan(0);
+    expect(dim.height).toBeGreaterThan(0);
+    // Children should have positions
+    expect(result.positions.has('b')).toBe(true);
+    expect(result.positions.has('c')).toBe(true);
+    expect(result.positions.has('g')).toBe(true);
+  });
+});
+
+// ── layoutGraph (public API) ─────────────────────────────────────
+
+describe('layoutGraph', () => {
+  it('works for flat graphs', () => {
+    const result = layoutGraph({
+      nodes: sizes('a', 'b', 'c'),
+      edges: [edge('a', 'b'), edge('a', 'c')],
+      hierarchy: { childToParent: new Map(), parentToChildren: new Map() },
+      previousPositions: new Map(),
+      options: { ...defaultOpts, groupPadding: defaultPad },
+    });
+    expect(result.positions.size).toBe(3);
+    expect(result.groupDimensions.size).toBe(0);
+  });
+
+  it('works for hierarchical graphs', () => {
+    const result = layoutGraph({
+      nodes: new Map([
+        ['g', { width: 100, height: 40 }],
+        ['a', { width: 100, height: 40 }],
+        ['b', { width: 100, height: 40 }],
+      ]),
+      edges: [edge('a', 'b')],
+      hierarchy: {
+        childToParent: new Map([['a', 'g'], ['b', 'g']]),
+        parentToChildren: new Map([['g', new Set(['a', 'b'])]]),
+      },
+      previousPositions: new Map(),
+      options: { ...defaultOpts, groupPadding: defaultPad },
+    });
+    expect(result.positions.size).toBe(3);
+    expect(result.groupDimensions.has('g')).toBe(true);
+  });
+
+  it('incremental: existing nodes keep their X and Y position', () => {
+    const s = sizes('a', 'b');
+    const prev = new Map([['a', { x: 100, y: 55 }]]);
+    const result = layoutGraph({
+      nodes: s,
+      edges: [edge('a', 'b')],
+      hierarchy: { childToParent: new Map(), parentToChildren: new Map() },
+      previousPositions: prev,
+      options: { ...defaultOpts, groupPadding: defaultPad },
+    });
+    expect(result.positions.get('a')!.x).toBe(100);
+    expect(result.positions.get('a')!.y).toBe(55);
+  });
+
+  it('produces deterministic output with independent inputs', () => {
+    const makeInput = () => ({
+      nodes: sizes('c', 'a', 'b'),
+      edges: [edge('a', 'b'), edge('a', 'c'), edge('b', 'c')],
+      hierarchy: { childToParent: new Map(), parentToChildren: new Map() },
+      previousPositions: new Map(),
+      options: { ...defaultOpts, groupPadding: defaultPad },
+    });
+    const r1 = layoutGraph(makeInput());
+    const r2 = layoutGraph(makeInput());
+    expect(Array.from(r1.positions)).toEqual(Array.from(r2.positions));
+  });
+
+  it('3-node all-cycle produces valid DAG', () => {
+    const result = layoutGraph({
+      nodes: sizes('a', 'b', 'c'),
+      edges: [edge('a', 'b'), edge('b', 'c'), edge('c', 'a', 'back')],
+      hierarchy: { childToParent: new Map(), parentToChildren: new Map() },
+      previousPositions: new Map(),
+      options: { ...defaultOpts, groupPadding: defaultPad },
+    });
+    expect(result.positions.size).toBe(3);
+    expect(result.backEdgeIds.size).toBeGreaterThan(0);
+  });
+
+  it('empty-children group does not crash', () => {
+    const result = layoutGraph({
+      nodes: new Map([['g', { width: 100, height: 40 }], ['a', { width: 100, height: 40 }]]),
+      edges: [],
+      hierarchy: {
+        childToParent: new Map(),
+        parentToChildren: new Map([['g', new Set<string>()]]),
+      },
+      previousPositions: new Map(),
+      options: { ...defaultOpts, groupPadding: defaultPad },
+    });
+    expect(result.positions.size).toBe(2);
+  });
+});

--- a/src/app/lib/use_graph_layout.ts
+++ b/src/app/lib/use_graph_layout.ts
@@ -16,17 +16,13 @@ import {
   type Node as GraphNode,
   buildHierarchy,
   filterRedundantEdges,
-  getPreservableNodeIds,
-  alignToPreservedPositions,
-  buildPreservedPositionsMap,
   splitMultiParentNodes,
   mergeSameNameNodes,
 } from '../graph';
 import type { CodeFocus } from '../code_viewer';
 import {
-  adjustParentDimensions,
-  layoutGraphWithDagre,
-  layoutGraphWithElk,
+  layoutGraph,
+  resolveNodeSize,
   resizeSingleParent,
 } from './graph_layout';
 import { setupGraphTestApis } from '../testing/graph_test_utils';
@@ -193,14 +189,6 @@ function migratePositionsForGraphChange(
   });
 }
 
-function hasNodeOverlap(previous: Graph | null, next: Graph) {
-  if (!previous || previous.nodes.size === 0 || next.nodes.size === 0) return false;
-  for (const nodeId of Array.from(next.nodes.keys())) {
-    if (previous.nodes.has(nodeId)) return true;
-  }
-  return false;
-}
-
 function splitSymbolWithOffsets(label: string): { tokens: string[]; offsets: number[] } {
   const tokens: string[] = [];
   const offsets: number[] = [];
@@ -329,7 +317,6 @@ export function useGraphLayout({
   const hierarchyRef = useRef<HierarchyInfo>({ childToParent: new Map(), parentToChildren: new Map() });
   const nodesRef = useRef<FlowNode<GraphNodeData>[]>([]);
   const graphRef = useRef<Graph | null>(null);
-  const layoutRunIdRef = useRef(0);
   const [layoutGen, setLayoutGen] = useState(0);
   const reactFlowInstanceRef = useRef<ReactFlowInstance | null>(null);
 
@@ -352,6 +339,26 @@ export function useGraphLayout({
             positionsRef.current.delete(change.id);
           }
         });
+        // When leaf nodes get measured for the first time, resize their
+        // parent groups so dimensions match what resizeSingleParent
+        // computes during interactive drag.
+        const measuredLeafIds: string[] = [];
+        changes.forEach((change) => {
+          if (change.type === 'dimensions' && !hierarchyRef.current.parentToChildren.has(change.id)) {
+            measuredLeafIds.push(change.id);
+          }
+        });
+        if (measuredLeafIds.length > 0 && hierarchyRef.current.parentToChildren.size > 0) {
+          const resized = resizeParentsForNodes(measuredLeafIds, nextNodes, hierarchyRef.current);
+          // Sync positionsRef so the next layout uses the corrected parent positions
+          for (const n of resized) {
+            const prev = positionsRef.current.get(n.id);
+            if (prev && (prev.x !== n.position.x || prev.y !== n.position.y)) {
+              positionsRef.current.set(n.id, n.position);
+            }
+          }
+          return resized;
+        }
         return nextNodes;
       });
     },
@@ -495,7 +502,6 @@ export function useGraphLayout({
 
     const graphChanged = graphRef.current !== mergedGraph;
     const hasHierarchy = hierarchy.childToParent.size > 0;
-    const shouldUseDagre = !hasHierarchy && !hasNodeOverlap(graphRef.current, mergedGraph);
     graphRef.current = mergedGraph;
 
     if (!graphChanged) {
@@ -503,108 +509,66 @@ export function useGraphLayout({
       return;
     }
 
-    const layoutRunId = ++layoutRunIdRef.current;
     const shouldApplyInitialPadding = positionsRef.current.size === 0;
-    const positionsSnapshot = new Map(positionsRef.current);
-
-    let preserveExisting: boolean;
-    let layoutPositions: Map<string, { x: number; y: number }>;
-
-    const hierarchyPreservedPositions =
-      hasHierarchy && !shouldUseDagre && positionsRef.current.size > 0
-        ? buildPreservedPositionsMap(
-            getPreservableNodeIds(hierarchyRef.current, hierarchy, positionsRef.current),
-            positionsRef.current,
-          )
-        : new Map<string, { x: number; y: number }>();
-
-    if (hasHierarchy && !shouldUseDagre && positionsRef.current.size > 0) {
-      const oldH = hierarchyRef.current;
-      positionsRef.current.forEach((pos, nodeId) => {
-        if (oldH.childToParent.has(nodeId) && !hierarchy.childToParent.has(nodeId)) {
-          hierarchyPreservedPositions.set(nodeId, pos);
-        }
-      });
-    }
-
-    if (hierarchyPreservedPositions.size > 0) {
-      const ensureAncestorsPreserved = (nodeId: string) => {
-        const parentId = hierarchy.childToParent.get(nodeId);
-        if (!parentId || hierarchyPreservedPositions.has(parentId)) return;
-        const pos = positionsRef.current.get(parentId);
-        if (pos) {
-          hierarchyPreservedPositions.set(parentId, pos);
-          ensureAncestorsPreserved(parentId);
-        }
-      };
-      Array.from(hierarchyPreservedPositions.keys()).forEach(ensureAncestorsPreserved);
-    }
-
-    if (shouldUseDagre || positionsRef.current.size === 0 || hasHierarchy) {
-      preserveExisting = false;
-      layoutPositions = new Map();
-    } else {
-      preserveExisting = true;
-      layoutPositions = new Map(positionsRef.current);
-    }
-
+    // Fit view when no node in the new graph has a carried-over position
+    // (including positions synthesized by migration for split↔unsplit transitions).
+    const hasCarriedPositions = nextNodes.some(n => positionsRef.current.has(n.id));
+    const shouldFitView = !hasCarriedPositions;
     hierarchyRef.current = hierarchy;
 
-    const shouldFitView = shouldUseDagre || (!preserveExisting && hierarchyPreservedPositions.size === 0);
-    const layoutPromise = shouldUseDagre
-      ? layoutGraphWithDagre(nextNodes, nextEdges)
-      : layoutGraphWithElk(nextNodes, nextEdges, {
-          preserveExisting,
-          positions: layoutPositions,
-          incremental: preserveExisting,
-          hierarchy: hasHierarchy ? hierarchy : undefined,
-        });
+    // Collect measured sizes from previous render for accurate centering
+    const measuredSizes = new Map<string, { width: number; height: number }>();
+    for (const n of nodesRef.current) {
+      const w = (n as any).measured?.width ?? n.width;
+      const h = (n as any).measured?.height ?? n.height;
+      if (w != null && h != null) measuredSizes.set(n.id, { width: w, height: h });
+    }
 
-    layoutPromise.then((layoutedNodes) => {
-      if (layoutRunId !== layoutRunIdRef.current) return;
+    const layoutedNodes = layoutGraph(
+      nextNodes,
+      nextEdges,
+      positionsRef.current,
+      hasHierarchy ? hierarchy : undefined,
+      measuredSizes.size > 0 ? measuredSizes : undefined,
+    );
 
-      const alignedNodes = hierarchyPreservedPositions.size > 0
-        ? alignToPreservedPositions(layoutedNodes, hierarchyPreservedPositions, hierarchy)
-        : layoutedNodes;
-
-      const measuredSizes = new Map<string, { width: number; height: number }>();
-      for (const n of nodesRef.current) {
-        const w = (n as any).measured?.width ?? n.width;
-        const h = (n as any).measured?.height ?? n.height;
-        if (w != null && h != null) {
-          measuredSizes.set(n.id, { width: w, height: h });
+    const paddedNodes = shouldApplyInitialPadding
+      ? applyLayoutPadding(layoutedNodes, INITIAL_NODE_OFFSET)
+      : layoutedNodes;
+    setNodes(paddedNodes);
+    positionsRef.current = new Map(
+      paddedNodes.map((node) => [node.id, node.position]),
+    );
+    setLayoutGen((g) => g + 1);
+    if (shouldFitView) {
+      const rfEl = typeof document !== 'undefined' ? document.querySelector('.react-flow') : null;
+      if (rfEl) {
+        const { width: vpW, height: vpH } = rfEl.getBoundingClientRect();
+        let gMinX = Infinity, gMaxX = -Infinity, gMinY = Infinity, gMaxY = -Infinity;
+        for (const n of paddedNodes) {
+          if ((n as any).parentNode) continue;
+          const s = resolveNodeSize(n);
+          gMinX = Math.min(gMinX, n.position.x);
+          gMaxX = Math.max(gMaxX, n.position.x + s.width);
+          gMinY = Math.min(gMinY, n.position.y);
+          gMaxY = Math.max(gMaxY, n.position.y + s.height);
+        }
+        if (Number.isFinite(gMinX) && vpW > 0 && vpH > 0) {
+          const gW = gMaxX - gMinX;
+          const gH = gMaxY - gMinY;
+          const zoom = Math.min(1, vpW / (gW * 1.4), vpH / (gH * 1.4));
+          const cx = (gMinX + gMaxX) / 2;
+          const cy = (gMinY + gMaxY) / 2;
+          requestAnimationFrame(() => {
+            reactFlowInstanceRef.current?.setViewport({
+              x: vpW / 2 - cx * zoom,
+              y: vpH / 2 - cy * zoom,
+              zoom,
+            });
+          });
         }
       }
-
-      const finalNodes = hierarchy.parentToChildren.size > 0
-        ? adjustParentDimensions(alignedNodes, hierarchy, measuredSizes)
-        : alignedNodes;
-
-      const paddedNodes = shouldApplyInitialPadding
-        ? applyLayoutPadding(finalNodes, INITIAL_NODE_OFFSET)
-        : finalNodes;
-      setNodes(paddedNodes);
-      positionsRef.current = new Map(
-        paddedNodes.map((node) => [node.id, node.position]),
-      );
-      setLayoutGen((g) => g + 1);
-      if (shouldFitView) {
-        requestAnimationFrame(() => {
-          reactFlowInstanceRef.current?.fitView({ padding: 0.2 });
-        });
-      }
-    }).catch((err) => {
-      console.error('Graph layout failed:', err);
-      if (layoutRunId !== layoutRunIdRef.current) return;
-      positionsRef.current = positionsSnapshot;
-      setNodes((current) =>
-        current.map((n) => {
-          const pos = positionsSnapshot.get(n.id);
-          return pos ? { ...n, position: pos } : n;
-        }),
-      );
-      setLayoutGen((g) => g + 1);
-    });
+    }
   }, [buildFlowElements, mergedGraph, setEdges, setNodes]);
 
   // ── Test API setup ─────────────────────────────────────────────────
@@ -616,27 +580,32 @@ export function useGraphLayout({
 
   // ── Manual re-layout ───────────────────────────────────────────────
 
-  const handleDagreLayout = useCallback(() => {
+  const handleRelayout = useCallback(() => {
     if (nodes.length === 0) return;
 
-    const layoutRunId = ++layoutRunIdRef.current;
-    const hasHierarchy = mergedGraph.has_edges.length > 0;
-    const layoutPromise = hasHierarchy
-      ? layoutGraphWithElk(nodes, edges, {
-          hierarchy: buildHierarchy(mergedGraph.has_edges, mergedGraph.nodes),
-        })
-      : layoutGraphWithDagre(nodes, edges);
-    layoutPromise.then((layoutedNodes) => {
-      if (layoutRunId !== layoutRunIdRef.current) return;
-      setNodes(layoutedNodes);
-      positionsRef.current = new Map(
-        layoutedNodes.map((node) => [node.id, node.position]),
-      );
-      requestAnimationFrame(() => {
-        reactFlowInstanceRef.current?.fitView({ padding: 0.2 });
-      });
-    }).catch((err) => {
-      console.error('Graph layout failed:', err);
+    // Collect measured sizes for accurate centering during relayout
+    const measured = new Map<string, { width: number; height: number }>();
+    for (const n of nodes) {
+      const w = (n as any).measured?.width ?? n.width;
+      const h = (n as any).measured?.height ?? n.height;
+      if (w != null && h != null) measured.set(n.id, { width: w, height: h });
+    }
+
+    const hierarchy = buildHierarchy(mergedGraph.has_edges, mergedGraph.nodes);
+    const hasHierarchy = hierarchy.childToParent.size > 0;
+    const layoutedNodes = layoutGraph(
+      nodes,
+      edges,
+      new Map(), // no previous positions = full relayout
+      hasHierarchy ? hierarchy : undefined,
+      measured.size > 0 ? measured : undefined,
+    );
+    setNodes(layoutedNodes);
+    positionsRef.current = new Map(
+      layoutedNodes.map((node) => [node.id, node.position]),
+    );
+    requestAnimationFrame(() => {
+      reactFlowInstanceRef.current?.fitView({ padding: 0.2, maxZoom: 1 });
     });
   }, [edges, mergedGraph, nodes, setNodes]);
 
@@ -652,8 +621,7 @@ export function useGraphLayout({
     hierarchyRef,
     nodesRef,
     reactFlowInstanceRef,
-    layoutRunIdRef,
     focusNode,
-    handleDagreLayout,
+    handleRelayout,
   };
 }

--- a/tests/multi-selection.spec.ts
+++ b/tests/multi-selection.spec.ts
@@ -85,7 +85,11 @@ test.describe('node selection', () => {
     await nodeWrapper(page, '4').click();
     await expect.poll(() => isNodeSelected(page, '4')).toBe(true);
 
-    await page.locator('.react-flow__pane').click();
+    // After viewport centering, the pane center may coincide with a node.
+    // Click an empty spot by finding the pane's top-left in absolute coords.
+    const rf = page.locator('.react-flow');
+    const rfBox = await rf.boundingBox();
+    await page.mouse.click(rfBox!.x + 2, rfBox!.y + 2);
     await expect.poll(() => isNodeSelected(page, '4')).toBe(false);
   });
 


### PR DESCRIPTION
Replace the ELK (layered) and Dagre layout backends with a new architecture:

- Fresh layouts use @dagrejs/dagre for coordinate assignment, which properly centers parents over children and handles subtree spacing.
- Incremental updates use a custom BFS-based placement that pins existing nodes and places new nodes near their neighbors, with direction-aware Y positioning (parents above, children below) and bounded overlap resolution.
- Nested/group nodes are handled by a hierarchy decomposer that processes groups bottom-up, calls the flat engine per level, lifts cross-group edges, and computes group dimensions.

Key improvements over the previous ELK-based layout:
- Existing nodes never move during incremental query updates
- Proper centering (dagre) instead of custom Sugiyama coordinate assignment with its many patches
- DOM-based node width measurement for accurate centering
- Viewport auto-centers on the graph for fresh queries
- Dimension-triggered parent resize for consistent drag behavior

Layout engine files:
- src/app/lib/layout/flat_layout.ts: DAG construction, dagre fresh layout, incremental BFS placement, connected components
- src/app/lib/layout/hierarchy.ts: nesting decomposer
- src/app/lib/layout/index.ts: public API
- src/app/lib/layout/layout.test.ts: 34 unit tests

Dependencies: removed elkjs, replaced dagre with @dagrejs/dagre.