### PR TITLE
Add Report tab showing the query markdown

### DIFF
--- a/src/app/askld.test.ts
+++ b/src/app/askld.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { markdownQueryParams } from './askld';
+
+describe('markdownQueryParams', () => {
+  it('requests markdown format with the given projection', () => {
+    expect(markdownQueryParams('signature')).toBe('format=markdown&projection=signature');
+    expect(markdownQueryParams('names')).toBe('format=markdown&projection=names');
+    expect(markdownQueryParams('body')).toBe('format=markdown&projection=body');
+  });
+});

--- a/src/app/askld.tsx
+++ b/src/app/askld.tsx
@@ -56,6 +56,36 @@ export function fetchQuery(query: string): Promise<Response> {
   });
 }
 
+/** How much source rides along in the markdown report. */
+export type Projection = 'names' | 'signature' | 'body';
+
+/** Build the query string for a markdown query request. Pure, for testing. */
+export function markdownQueryParams(projection: Projection): string {
+  return new URLSearchParams({ format: 'markdown', projection }).toString();
+}
+
+let markdownAbortController: AbortController | null = null;
+
+/**
+ * Fetch the same markdown report the MCP renderer produces (backend-rendered,
+ * one source of truth). Uses a separate abort controller so it never cancels
+ * the main JSON query used by the graph view.
+ */
+export function fetchQueryMarkdown(query: string, projection: Projection): Promise<Response> {
+  if (markdownAbortController) {
+    markdownAbortController.abort();
+  }
+  markdownAbortController = new AbortController();
+  return fetch(`${askldUrl}/query?${markdownQueryParams(projection)}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/plain'
+    },
+    body: query,
+    signal: markdownAbortController.signal,
+  });
+}
+
 export function fetchProjects(): Promise<Response> {
   return fetch(`${askldUrl}/v1/index/projects`, {
     method: 'GET',

--- a/src/app/editor.tsx
+++ b/src/app/editor.tsx
@@ -23,6 +23,8 @@ interface EditorProps {
     query: string;
     onGraphChange: (graph: Graph) => void;
     onProblemsChange?: (problems: Problem[]) => void;
+    /** Fires with the query text each time a query is successfully run. */
+    onQueryRun?: (queryText: string) => void;
 }
 
 type RustGraphObjectEntry = { object_id: string; path: string; project_id?: string | null };
@@ -252,7 +254,7 @@ async function handleQueryFailure(response: Response, monacoInstance: Monaco | n
     }
 }
 
-export const EditorComponent = React.forwardRef<EditorHandle, EditorProps>(function EditorComponent({ query, onGraphChange, onProblemsChange }: EditorProps, ref) {
+export const EditorComponent = React.forwardRef<EditorHandle, EditorProps>(function EditorComponent({ query, onGraphChange, onProblemsChange, onQueryRun }: EditorProps, ref) {
     const testCleanupRef = useRef<(() => void) | null>(null);
     const monacoRef = useRef<Monaco | null>(null);
     const editorInstanceRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
@@ -303,6 +305,7 @@ export const EditorComponent = React.forwardRef<EditorHandle, EditorProps>(funct
             onGraphChange(
                 { nodes: nodes, edges: edgeMap, has_edges: data.has_edges ?? [], objects: objects }
             );
+            onQueryRun?.(queryText);
             clearEditorErrorMarker(monacoRef.current, ed);
             const warningProblems = buildProblemsFromWarnings(data.warnings, queryText);
             onProblemsChange?.(warningProblems);
@@ -311,7 +314,7 @@ export const EditorComponent = React.forwardRef<EditorHandle, EditorProps>(funct
             applyEditorErrorMarker(monacoRef.current, ed, 'Unable to submit query. Please try again.');
             onProblemsChange?.([buildProblem('Unable to submit query. Please try again.', 'error', defaultMarkerRange)]);
         }
-    }, [onGraphChange, onProblemsChange]);
+    }, [onGraphChange, onProblemsChange, onQueryRun]);
 
     const runQuery = useCallback((editorInstance?: MonacoEditor.ICodeEditor) => {
         const activeEditor = editorInstance ?? editorInstanceRef.current;

--- a/src/app/markdown_report.tsx
+++ b/src/app/markdown_report.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Editor } from '@monaco-editor/react';
+import { fetchQueryMarkdown, Projection } from './askld';
+
+/**
+ * Renders the report text in a read-only Monaco editor. The report is
+ * whitespace-aligned, line-oriented text (indented `→` children, fenced code),
+ * so it must be shown monospace with whitespace preserved — an HTML markdown
+ * renderer would collapse the alignment. This also matches exactly what an AI
+ * agent receives from the MCP.
+ */
+export function MarkdownView({ content }: { content: string }) {
+  // Absolutely fill the (relative) parent so Monaco measures a concrete pixel
+  // box. A percentage/flex height chain collapses to zero when the Find widget
+  // (Ctrl+F) forces a re-layout, making the text vanish. `domReadOnly` is
+  // deliberately not set — it interferes with the Find widget.
+  return (
+    <div className="absolute inset-0">
+      <Editor
+        height="100%"
+        language="markdown"
+        value={content}
+        options={{
+          readOnly: true,
+          automaticLayout: true,
+          minimap: { enabled: false },
+          wordWrap: 'off',
+          lineNumbers: 'off',
+          scrollBeyondLastLine: false,
+          folding: false,
+          renderWhitespace: 'none',
+          fontSize: 12,
+        }}
+      />
+    </div>
+  );
+}
+
+export interface MarkdownReportProps {
+  /** The last successfully-run query (may be empty before the first run). */
+  query: string;
+}
+
+/** A completed fetch, tagged with the query/projection it was fetched for. */
+interface Report {
+  query: string;
+  projection: Projection;
+  content: string;
+  error: string;
+}
+
+/**
+ * Shows the backend-rendered markdown report for the current query — the exact
+ * output an AI agent gets from the MCP. Fetches lazily when mounted and whenever
+ * the query or projection changes.
+ */
+export function MarkdownReport({ query }: MarkdownReportProps) {
+  const [projection, setProjection] = useState<Projection>('signature');
+  const [report, setReport] = useState<Report | null>(null);
+
+  const hasQuery = query.trim().length > 0;
+
+  useEffect(() => {
+    if (!hasQuery) {
+      return;
+    }
+
+    let cancelled = false;
+    fetchQueryMarkdown(query, projection)
+      .then(async (res) => {
+        const text = await res.text();
+        if (cancelled) return;
+        setReport({
+          query,
+          projection,
+          content: res.ok ? text : '',
+          error: res.ok ? '' : text || `Request failed (${res.status})`,
+        });
+      })
+      .catch((err: unknown) => {
+        if (cancelled || (err instanceof DOMException && err.name === 'AbortError')) {
+          return;
+        }
+        setReport({ query, projection, content: '', error: String(err) });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [query, projection, hasQuery]);
+
+  // Derive loading from whether the stored report matches the current inputs,
+  // rather than tracking a 'loading' status with a synchronous setState in the
+  // effect (which triggers cascading renders).
+  const current = report && report.query === query && report.projection === projection ? report : null;
+  const loading = hasQuery && !current;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-gray-200 p-2 text-sm">
+        <label htmlFor="report-projection" className="text-muted">Detail</label>
+        <select
+          id="report-projection"
+          className="rounded border border-gray-300 px-1 py-0.5 text-sm"
+          value={projection}
+          onChange={(e) => setProjection(e.target.value as Projection)}
+        >
+          <option value="names">names</option>
+          <option value="signature">signature</option>
+          <option value="body">body</option>
+        </select>
+      </div>
+      <div className="relative min-h-0 flex-1">
+        {!hasQuery && (
+          <div className="p-6 text-sm text-muted">Run a query to see its report.</div>
+        )}
+        {loading && (
+          <div className="p-4 text-sm text-muted">Rendering report…</div>
+        )}
+        {current && current.error && (
+          <pre className="whitespace-pre-wrap p-4 text-sm text-red-600">{current.error}</pre>
+        )}
+        {current && !current.error && <MarkdownView content={current.content} />}
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Layout, Model, TabNode, type IJsonModel, Actions } from 'flexlayout-react';
 import 'flexlayout-react/style/light.css';
 import { EditorComponent, EditorHandle } from './editor';
@@ -9,7 +9,8 @@ import { CodeViewer, CodeFocus } from './code_viewer';
 import { GraphViewer, type GraphViewerHandle } from './graph_viewer';
 import { DEFAULT_QUERY } from './default-queries';
 import { Problems, Problem } from './problems';
-import { formatOffsetLocation, getLineColumnFromOffset } from './lib/offsets';
+import { MarkdownReport } from './markdown_report';
+import { getLineColumnFromOffset } from './lib/offsets';
 import { UnifiedToolbar, type ShareStatus } from './unified_toolbar';
 import { readLastQuery } from './lib/last_query';
 import { buildShareUrl, getQueryFromHash } from './lib/query_share';
@@ -87,8 +88,8 @@ const initialLayout: IJsonModel = {
               },
               {
                 type: "tab",
-                id: "Two",
-                name: "Nodes",
+                id: "markdown-report",
+                name: "Report",
                 component: "button",
               }
             ]
@@ -114,60 +115,6 @@ const initialLayout: IJsonModel = {
   }
 };
 
-export interface GraphCodeProps {
-  graph: Graph;
-  fileContents: Map<string, string>;
-}
-
-function GraphCode({ graph, fileContents }: GraphCodeProps) {
-  function get_id(data: any) {
-    if ('id' in data) {
-      return data.id;
-    } else {
-      return data.from + '-' + data.to;
-    }
-  }
-
-  function get_str(data: any) {
-    if ('label' in data) {
-      return data.label;
-    } else {
-      return data.from + ' -> ' + data.to;
-    }
-  }
-
-  function resolveEdgeObjectId(edge: Edge): string | null {
-    if (edge.from_object) {
-      return edge.from_object;
-    }
-
-    const node = graph.nodes.get(edge.from);
-    return node?.symbol_instances[0]?.object_id ?? null;
-  }
-
-  function get_loc(edge: Edge): string {
-    const objectId = resolveEdgeObjectId(edge);
-    const filePath = objectId ? graph.objects.get(objectId)?.path ?? objectId : 'Unknown';
-    const location = formatOffsetLocation(objectId ? fileContents.get(objectId) : undefined, edge.from_offset_start);
-    return `${filePath}:${location}`;
-  }
-
-  return (<>
-    <ul>
-      {Array.from(graph.nodes.entries()).map(([id, node]: [string, Node]) => <li key={id}>{get_str(node)}</li>)}
-    </ul>
-    <ul>
-      {
-        Array.from(graph.edges.values()).map((edgeArray: Array<Edge>) =>
-          <li key={get_id(edgeArray[0])}>{get_str(edgeArray[0])}
-            <ul>
-              {edgeArray.map((edge: Edge) => <li key={get_loc(edge)}> {get_loc(edge)} </li>)}
-            </ul>
-          </li>)}
-    </ul>
-  </>);
-}
-
 export default function Home() {
   const [model] = useState(() => Model.fromJson(initialLayout));
   const [query, setQuery] = useState(() => readLastQuery() ?? DEFAULT_QUERY);
@@ -178,6 +125,7 @@ export default function Home() {
     objects: new Map<string, GraphObject>(),
   });
   const [problems, setProblems] = useState<Problem[]>([]);
+  const [lastRunQuery, setLastRunQuery] = useState('');
   const editorHandleRef = useRef<EditorHandle | null>(null);
   const graphViewerRef = useRef<GraphViewerHandle>(null);
   const [shareStatus, setShareStatus] = useState<ShareStatus>('idle');
@@ -410,6 +358,7 @@ export default function Home() {
             query={query}
             onGraphChange={setQueryGraph}
             onProblemsChange={handleProblemsChange}
+            onQueryRun={setLastRunQuery}
           />
         );
       case "file-explorer":
@@ -440,10 +389,12 @@ export default function Home() {
         );
       case PROBLEMS_TAB_ID:
         return <Problems problems={problems} onSelectProblem={handleProblemSelect} />;
+      case "markdown-report":
+        return <MarkdownReport query={lastRunQuery} />;
       default:
-        return <GraphCode graph={queryGraph} fileContents={fileContents} />;
+        return null;
     }
-  }, [activeFileId, activeFileNonce, autoMerge, codeTabs, codeTabsRef, effectiveMode, ensureFileContent, explorerReveal, fileContents, fileTreeCache, handleOpenFileFromExplorer, handleProblemSelect, handleProblemsChange, handleRevealDirectory, handleRevealQueryRange, handleSelectFile, panOnDrag, problems, query, queryGraph, selectionOnDrag]);
+  }, [activeFileId, activeFileNonce, autoMerge, codeTabs, codeTabsRef, effectiveMode, ensureFileContent, explorerReveal, fileContents, fileTreeCache, handleOpenFileFromExplorer, handleProblemSelect, handleProblemsChange, handleRevealDirectory, handleRevealQueryRange, handleSelectFile, lastRunQuery, panOnDrag, problems, query, queryGraph, selectionOnDrag]);
 
   return (
     <main className="flex h-full flex-col">


### PR DESCRIPTION
Replace the Nodes tab with a Report tab that fetches the backend-rendered markdown (POST /query?format=markdown) for the last-run query and shows it in a read-only Monaco editor, so whitespace/alignment are preserved and the output matches exactly what the MCP delivers. Adds a projection selector (names/signature/body), a fetchQueryMarkdown helper with its own abort controller, and an onQueryRun callback to track the last-run query.