### PR TITLE
Show did-you-mean suggestions in the Problems tab

### DIFF
--- a/src/app/editor.tsx
+++ b/src/app/editor.tsx
@@ -11,6 +11,7 @@ import { registerAskl } from './monaco-askl-language';
 import { Problem } from './problems';
 import { getLineColumnFromOffset } from './lib/offsets';
 import { writeLastQuery } from './lib/last_query';
+import { warningMessage } from './lib/warnings';
 
 export interface EditorHandle {
     revealRange: (range: IRange) => void;
@@ -43,6 +44,12 @@ interface QueryDiagnostic {
     line_col?: LineColLocation;
     path?: string | null;
     line?: string;
+    /** Typed name for a no-match diagnostic (e.g. `vfs_rea`). */
+    token?: string | null;
+    /** Nearest existing symbol names for a no-match typo. */
+    suggestions?: string[];
+    /** True when the name exists but was excluded by a filter/scope. */
+    name_exists?: boolean;
 }
 
 type PositionTuple = [number, number];
@@ -228,7 +235,7 @@ function buildProblemsFromWarnings(warnings: QueryDiagnostic[] | undefined, sour
 
     return warnings.map(warning => {
         const range = getRangeFromLocation(sourceText, warning.location, warning.line_col);
-        return buildProblem(warning.message ?? 'Warning', 'warning', range, {
+        return buildProblem(warningMessage(warning), 'warning', range, {
             source: warning.path ?? 'warning',
             lineText: warning.line ?? null,
         });

--- a/src/app/lib/warnings.test.ts
+++ b/src/app/lib/warnings.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { warningMessage } from './warnings';
+
+describe('warningMessage', () => {
+  it('appends suggestions for a typo', () => {
+    expect(
+      warningMessage({ message: '`"vfs_rea"` matched no symbols', suggestions: ['vfs_read', 'vfs_readv'] }),
+    ).toBe('`"vfs_rea"` matched no symbols. Did you mean: vfs_read, vfs_readv?');
+  });
+
+  it('phrases name_exists when there are no suggestions', () => {
+    const out = warningMessage({ message: '`"vfs_read"` matched no symbols', name_exists: true });
+    expect(out).toContain('The name exists but wasn\'t matched here');
+    expect(out).toContain('type');
+    expect(out).not.toContain('Did you mean');
+  });
+
+  it('suggestions win over name_exists', () => {
+    const out = warningMessage({ message: 'x', suggestions: ['y'], name_exists: true });
+    expect(out).toBe('x. Did you mean: y?');
+  });
+
+  it('returns the base message when neither is present', () => {
+    expect(warningMessage({ message: 'plain warning' })).toBe('plain warning');
+    expect(warningMessage({})).toBe('Warning');
+    expect(warningMessage({ message: 'x', suggestions: [] })).toBe('x');
+  });
+});

--- a/src/app/lib/warnings.ts
+++ b/src/app/lib/warnings.ts
@@ -1,0 +1,29 @@
+/**
+ * A query warning as returned by the backend (`ErrorResponse`), with the
+ * structured no-match fields M3 added. Only the fields this helper reads are
+ * declared; the full diagnostic carries location/line_col too.
+ */
+export interface WarningDiagnostic {
+  message?: string;
+  /** Nearest existing symbol names for a no-match typo. */
+  suggestions?: string[];
+  /** True when the name exists but was excluded by a filter/scope. */
+  name_exists?: boolean;
+}
+
+/**
+ * The message shown for a warning, augmented with the same self-correction
+ * hints the markdown report renders — "Did you mean" for a typo, or the
+ * "name exists but wasn't matched here" note. Backticks are omitted because the
+ * Problems tab is plain monospace text, not markdown. Pure, for testing.
+ */
+export function warningMessage(warning: WarningDiagnostic): string {
+  const base = warning.message ?? 'Warning';
+  if (warning.suggestions && warning.suggestions.length > 0) {
+    return `${base}. Did you mean: ${warning.suggestions.join(', ')}?`;
+  }
+  if (warning.name_exists) {
+    return `${base}. The name exists but wasn't matched here — check the type, project, or relationship (caller/callee) filters.`;
+  }
+  return base;
+}


### PR DESCRIPTION
The backend already returns `suggestions`/`name_exists` on no-match warnings, but the Problems tab showed only the base message. Fold the same self-correction hints the markdown report renders into the warning message: "Did you mean: …" for a typo, or a "the name exists but wasn't matched here" note otherwise. Extracted as a pure `warningMessage` helper (lib/warnings.ts) with unit tests.